### PR TITLE
Updated EYP Germany Address

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-signaturen.eyp.de
+signaturen.fehlert.eu

--- a/index.html
+++ b/index.html
@@ -52,9 +52,7 @@
         <address>
           Europäisches Jugendparlament in Deutschland e.V.
           <br />
-          Kulturschöpfer Bürogemeinschaft
-          <br />
-          Grünberger Str. 13 | 10243 Berlin
+          Sophienstraße 28/29 | 10178 Berlin
           <br />
           Tel.: +49 (0) 30 62 93 83 28
         </address>


### PR DESCRIPTION
EYP Germany moved back into Sophienstraße / EYP IO.
Update the address to keep the Signaturengenerator up to date.