### PR TITLE
Adressänderung: Das EJP ist wieder zurück in die Sophienstraße/SSJE gezogen

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,9 +52,9 @@
         <address>
           Europäisches Jugendparlament in Deutschland e.V.
           <br />
-          MACHWERK in der Alten Münze
+          c/o Kulturschöpfer e.V.
           <br />
-          Am Krögel 2 | 10179 Berlin
+          Grünberger Str. 13 | 10243 Berlin
           <br />
           Tel.: +49 (0) 30 62 93 83 28
         </address>

--- a/index.html
+++ b/index.html
@@ -52,9 +52,9 @@
         <address>
           Europäisches Jugendparlament in Deutschland e.V.
           <br />
-          c/o Kulturschöpfer e.V.
+          <Sophienstraße 28/29
           <br />
-          Grünberger Str. 13 | 10243 Berlin
+          10178 Berlin
           <br />
           Tel.: +49 (0) 30 62 93 83 28
         </address>

--- a/index.html
+++ b/index.html
@@ -52,9 +52,7 @@
         <address>
           Europäisches Jugendparlament in Deutschland e.V.
           <br />
-          Sophienstraße 28/29
-          <br />
-          10178 Berlin
+          Sophienstraße 28/29 | 10178 Berlin
           <br />
           Tel.: +49 (0) 30 62 93 83 28
         </address>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         <address>
           Europäisches Jugendparlament in Deutschland e.V.
           <br />
-          <Sophienstraße 28/29
+          Sophienstraße 28/29
           <br />
           10178 Berlin
           <br />


### PR DESCRIPTION
Neue Adresse: 

Europäisches Jugendparlament in Deutschland e.V.
Sophienstraße 28/29 | 10178 Berlin